### PR TITLE
fix analytic jacobian for col_deriv=1

### DIFF
--- a/leastsqbound.py
+++ b/leastsqbound.py
@@ -299,7 +299,10 @@ def leastsqbound(func, x0, args=(), bounds=None, Dfun=None, full_output=0,
             maxfev = 100 * (n + 1)
 
         def wDfun(x, *args):  # wrapped Dfun
-            return Dfun(i2e(x), *args) * _internal2external_grad(x, bounds)
+            scale = _internal2external_grad(x, bounds)
+            if col_deriv == 1:
+                scale = scale.reshape(len(x), 1)
+            return Dfun(i2e(x), *args)*scale
 
         retval = _minpack._lmder(wfunc, wDfun, i0, args, full_output,
                                  col_deriv, ftol, xtol, gtol, maxfev,


### PR DESCRIPTION
The solution in PR #7 works only for row-based Jacobians, not with `col_deriv=1`.   This PR checks `col_deriv` in the wrapped jacobian, and reshapes the internal-to-external gradient appropriately.

An example script is at  https://gist.github.com/newville/09747a8d09ad71efb1ed
